### PR TITLE
Return empty array instead of null from fetchIncludableElements()

### DIFF
--- a/fields/field.publish_tabs.php
+++ b/fields/field.publish_tabs.php
@@ -70,7 +70,7 @@
 	-------------------------------------------------------------------------*/
 
 		public function fetchIncludableElements() {
-			return null;
+			return array();
 		}
 
 		public function appendFormattedElement(XMLElement &$wrapper, $data, $encode = false, $mode = NULL, $entry_id = NULL) {


### PR DESCRIPTION
Some extensions always expect an array to be returned from fetchIncludableElements() (i.e. the association_output extension). Returning an empty array instead of null resolves an issue where a warning would be raised if another extension attempts to iterate over the result of this method without checking it first. 
